### PR TITLE
Add `Network.Wait.Redis` - Redis support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,7 @@ on:
       - ".github/workflows/**"
       - "src/**"
       - "test/**"
+      - "test-postgres/**"
       - "package.yaml"
       - "stack*.yaml"
   pull_request:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ on:
       - "src/**"
       - "test/**"
       - "test-postgres/**"
+      - "test-redis/**"
       - "package.yaml"
       - "stack*.yaml"
   pull_request:
@@ -26,6 +27,9 @@ jobs:
         postgres-flag:
           - ""
           - "--flag network-wait:postgres"
+        redis-flag:
+          - ""
+          - "--flag network-wait:redis"
 
     runs-on: ubuntu-latest
 
@@ -42,6 +46,7 @@ jobs:
       - name: Write flags to file (for hashing)
         run: |
           echo ${{ matrix.postgres-flag }} > .cabal-flags
+          echo ${{ matrix.redis-flag }} >> .cabal-flags
           cat .cabal-flags
 
       - name: Cache .stack
@@ -56,21 +61,43 @@ jobs:
             ${{ runner.os }}-${{ matrix.resolver }}-
 
       - name: Install dependencies
-        run: stack --system-ghc --stack-yaml=${{ matrix.resolver }}.yaml --no-terminal build ${{ matrix.postgres-flag }} --only-dependencies --test --haddock --fast
+        run: |
+          stack --system-ghc --stack-yaml=${{ matrix.resolver }}.yaml --no-terminal build \
+            ${{ matrix.postgres-flag }} \
+            ${{ matrix.redis-flag }} \
+            --only-dependencies --test --haddock --fast
 
       - name: Build
         id: build
-        run: stack --system-ghc --stack-yaml=${{ matrix.resolver }}.yaml --no-terminal build ${{ matrix.postgres-flag }} --fast --test --no-run-tests
+        run: |
+          stack --system-ghc --stack-yaml=${{ matrix.resolver }}.yaml --no-terminal build \
+            ${{ matrix.postgres-flag }} \
+            ${{ matrix.redis-flag }} \
+            --fast --test --no-run-tests
 
       - name: Start Docker containers (PostgreSQL)
         if: ${{ contains(matrix.postgres-flag, 'network-wait:postgres') }}
         run: |
-          docker-compose -f docker-compose.postgresql.yaml up -d
+          docker-compose -p postgres -f docker-compose.postgresql.yaml up -d
+
+      - name: Start Docker containers (Redis)
+        if: ${{ contains(matrix.redis-flag, 'network-wait:redis') }}
+        run: |
+          docker-compose -p redis -f docker-compose.redis.yaml up -d
 
       - name: Test
-        run: stack --system-ghc --stack-yaml=${{ matrix.resolver }}.yaml --no-terminal build ${{ matrix.postgres-flag }} --fast --test
+        run: |
+          stack --system-ghc --stack-yaml=${{ matrix.resolver }}.yaml --no-terminal build \
+            ${{ matrix.postgres-flag }} \
+            ${{ matrix.redis-flag }} \
+            --fast --test
 
       - name: Stop Docker containers (PostgreSQL)
         if: ${{ contains(matrix.postgres-flag, 'network-wait:postgres') }}
         run: |
-          docker-compose -f docker-compose.postgresql.yaml down
+          docker-compose -p postgres -f docker-compose.postgresql.yaml down
+
+      - name: Stop Docker containers (Redis)
+        if: ${{ contains(matrix.redis-flag, 'network-wait:redis') }}
+        run: |
+          docker-compose -p redis -f docker-compose.redis.yaml down

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ cabal.project.local
 cabal.project.local~
 .HTF/
 .ghc.environment.*
+
+.DS_Store
+.envrc

--- a/README.md
+++ b/README.md
@@ -37,6 +37,25 @@ Internally, this uses `postgresql-simple` to connect to the specified server (`d
 
 The `Network.Wait.PostgreSQL` module is gated behind the `network-wait:postgres` flag so that the PostgreSQL-specific dependencies are only required when PostgresSQL support is required by users of this library.
 
+## Example: Redis
+
+The `network-wait` package can be compiled with the `network-wait:redis` flag (e.g. `stack build --flag network-wait:redis`) which enables support for checking the readiness of Redis servers specifically. Unlike the functions in the `Network.Wait` module, which only check that connections can be established, the functions in `Network.Wait.Redis` also check that a Redis server is ready to accept commands. To wait for a Redis server to become available and accept commands:
+
+```haskell
+import Control.Retry (retryPolicyDefault)
+import Database.Redis (defaultConnectInfo)
+import Network.Wait.Redis (waitRedis)
+
+main :: IO ()
+main = do
+    waitRedis retryPolicyDefault defaultConnectInfo
+    putStrLn "Yay, the Redis server is ready to accept commands!"
+```
+
+Internally, this uses `hedis` to connect to the specified server (`defaultConnectInfo` in the example above) and send a ping. If the ping is answered, we consider the server to be in a state ready to accept commands.
+
+The `Network.Wait.Redis` module is gated behind the `network-wait:redis` flag so that the Redis-specific dependencies are only required when Redis support is required by users of this library.
+
 ## See also
 
 - [wait-for](https://github.com/eficode/wait-for) is a popular shell script with the same objectives as this library.

--- a/docker-compose.postgresql.yaml
+++ b/docker-compose.postgresql.yaml
@@ -14,3 +14,8 @@ services:
       start_period: 30s
     ports:
       - 5432:5432
+    networks:
+      - postgres-network
+
+networks:
+  postgres-network:

--- a/docker-compose.redis.yaml
+++ b/docker-compose.redis.yaml
@@ -1,0 +1,12 @@
+version: "3"
+
+services:
+  redis:
+    image: redis:7-alpine3.15
+    ports:
+      - 6379:6379
+    networks:
+      - redis-network
+
+networks:
+  redis-network:

--- a/network-wait.cabal
+++ b/network-wait.cabal
@@ -30,6 +30,11 @@ flag postgres
   manual: True
   default: False
 
+flag redis
+  description: Enable Redis support.
+  manual: True
+  default: False
+
 library
   exposed-modules:
       Network.Wait
@@ -46,9 +51,15 @@ library
   if flag(postgres)
     build-depends:
         postgresql-simple
+  if flag(redis)
+    build-depends:
+        hedis
   if flag(postgres)
     exposed-modules:
         Network.Wait.PostgreSQL
+  if flag(redis)
+    exposed-modules:
+        Network.Wait.Redis
   default-language: Haskell2010
 
 test-suite network-wait-test
@@ -71,6 +82,9 @@ test-suite network-wait-test
   if flag(postgres)
     build-depends:
         postgresql-simple
+  if flag(redis)
+    build-depends:
+        hedis
   default-language: Haskell2010
 
 test-suite network-wait-test-postgres
@@ -92,6 +106,9 @@ test-suite network-wait-test-postgres
   if flag(postgres)
     build-depends:
         postgresql-simple
+  if flag(redis)
+    build-depends:
+        hedis
   if flag(postgres)
     buildable: True
   else

--- a/network-wait.cabal
+++ b/network-wait.cabal
@@ -114,3 +114,31 @@ test-suite network-wait-test-postgres
   else
     buildable: False
   default-language: Haskell2010
+
+test-suite network-wait-test-redis
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  other-modules:
+      Paths_network_wait
+  hs-source-dirs:
+      test-redis
+  ghc-options: -Wall
+  build-depends:
+      base >=4.7 && <5
+    , exceptions
+    , network
+    , network-wait
+    , retry
+    , tasty
+    , tasty-hunit
+  if flag(postgres)
+    build-depends:
+        postgresql-simple
+  if flag(redis)
+    build-depends:
+        hedis
+  if flag(redis)
+    buildable: True
+  else
+    buildable: False
+  default-language: Haskell2010

--- a/network-wait.cabal
+++ b/network-wait.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           network-wait
-version:        0.1.2.0
+version:        0.2.0.0
 synopsis:       Lightweight library for waiting on networked services to become available.
 description:    Please see the README on GitHub at <https://github.com/mbg/network-wait#readme>
 category:       Network

--- a/package.yaml
+++ b/package.yaml
@@ -26,11 +26,18 @@ flags:
     description: Enable Postgres support.
     manual: true
     default: false
+  redis:
+    description: Enable Redis support.
+    manual: true
+    default: false
 
 when:
-  condition: flag(postgres)
-  dependencies:
-    - postgresql-simple
+  - condition: flag(postgres)
+    dependencies:
+      - postgresql-simple
+  - condition: flag(redis)
+    dependencies:
+      - hedis
 
 ghc-options:
   - -Wall
@@ -38,8 +45,10 @@ ghc-options:
 library:
   source-dirs: src
   when:
-    condition: flag(postgres)
-    exposed-modules: Network.Wait.PostgreSQL
+    - condition: flag(postgres)
+      exposed-modules: Network.Wait.PostgreSQL
+    - condition: flag(redis)
+      exposed-modules: Network.Wait.Redis
 
 tests:
   network-wait-test:

--- a/package.yaml
+++ b/package.yaml
@@ -72,3 +72,16 @@ tests:
         buildable: true
       else:
         buildable: false
+  network-wait-test-redis:
+    main: Spec.hs
+    source-dirs: test-redis
+    dependencies:
+      - network-wait
+      - tasty
+      - tasty-hunit
+    when:
+      condition: flag(redis)
+      then:
+        buildable: true
+      else:
+        buildable: false

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: network-wait
-version: 0.1.2.0
+version: 0.2.0.0
 github: "mbg/network-wait"
 license: MIT
 author: "Michael B. Gale"

--- a/src/Network/Wait.hs
+++ b/src/Network/Wait.hs
@@ -161,7 +161,7 @@ waitSocketWith hs policy addr =
 -- the standard output or a logger.
 recoveringWith
     :: (MonadIO m, MonadMask m)
-    => [RetryStatus -> Handler m Bool] -> RetryPolicyM m -> m () -> m ()
+    => [RetryStatus -> Handler m Bool] -> RetryPolicyM m -> m a -> m a
 recoveringWith hs policy action =
     -- apply the retry policy to the following code, with the combinations of
     -- the `skipAsyncExceptions`, given, and default handlers. The order of

--- a/src/Network/Wait/Redis.hs
+++ b/src/Network/Wait/Redis.hs
@@ -1,0 +1,84 @@
+-------------------------------------------------------------------------------
+-- network-wait
+-- Copyright 2022 Michael B. Gale (github@michael-gale.co.uk)
+-------------------------------------------------------------------------------
+
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+-- | This module exports variants of the functions from "Network.Wait"
+-- specialised for Redis servers. In addition to checking whether a
+-- connection can be established, the functions in this module also check
+-- whether the Redis server is ready to accept commands using
+-- `checkedConnect`. Unlike `checkedConnect`, we don't give up if the
+-- connection fails, but instead use the specified retry policy to try again.
+-- All functions in this module return the established connection if
+-- successful.
+module Network.Wait.Redis (
+    waitRedis,
+    waitRedisVerbose,
+    waitRedisVerboseFormat,
+    waitRedisWith
+) where
+
+-------------------------------------------------------------------------------
+
+import Control.Monad.Catch
+import Control.Monad.IO.Class
+import Control.Retry
+
+import Database.Redis
+
+import Network.Wait
+
+-------------------------------------------------------------------------------
+
+
+-- | `waitRedis` @retryPolicy connectInfo@ is a variant of
+-- `waitRedisWith` which does not install any additional handlers.
+waitRedis
+    :: (MonadIO m, MonadMask m)
+    => RetryPolicyM m -> ConnectInfo -> m Connection
+waitRedis = waitRedisWith []
+
+-- | `waitRedisVerbose` @outputHandler retryPolicy connectInfo@ is a variant
+-- of `waitRedisVerboseFormat` which catches all exceptions derived from
+-- `SomeException` and formats retry attempt information using `defaultLogMsg`
+-- before passing the resulting `String` to @out@.
+waitRedisVerbose
+    :: (MonadIO m, MonadMask m)
+    => (String -> m ()) -> RetryPolicyM m -> ConnectInfo -> m Connection
+waitRedisVerbose out =
+    waitRedisVerboseFormat @SomeException $
+    \b ex st -> out $ defaultLogMsg b ex st
+
+-- | `waitRedisVerboseFormat` @outputHandler retryPolicy connectInfo@ is a
+-- variant of `waitRedisWith` which installs an extra handler based on
+-- `logRetries` which passes status information for each retry attempt
+-- to @outputHandler@.
+waitRedisVerboseFormat
+    :: forall e m . (MonadIO m, MonadMask m, Exception e)
+    => (Bool -> e -> RetryStatus -> m ())
+    -> RetryPolicyM m
+    -> ConnectInfo
+    -> m Connection
+waitRedisVerboseFormat out = waitRedisWith [h]
+    where h = logRetries (const $ pure True) out
+
+-- | `waitRedisWith` @extraHandlers retryPolicy connectInfo@ will attempt
+-- to connect to the Redis server using @connectInfo@ and check that the
+-- server is ready to accept commands. If this check fails, @retryPolicy@ is
+-- used to determine whether (and how often) this function should attempt to
+-- retry establishing the connection. By default, this function will retry
+-- after all exceptions (except for those given by `skipAsyncExceptions`).
+-- This behaviour may be customised with @extraHandlers@ which are installed
+-- after `skipAsyncExceptions`, but before the default exception handler. The
+--  @extraHandlers@ may also be used to report retry attempts to e.g. the
+-- standard output or a logger.
+waitRedisWith
+    :: (MonadIO m, MonadMask m)
+    => [RetryStatus -> Handler m Bool] -> RetryPolicyM m -> ConnectInfo
+    -> m Connection
+waitRedisWith hs policy = recoveringWith hs policy . liftIO . checkedConnect
+
+-------------------------------------------------------------------------------


### PR DESCRIPTION
This adds a new module, `Network.Wait.Redis`, which is gated behind the `network-wait:redis` flag and adds functions for waiting on Redis servers.