### PR TITLE
Add timeout to connect attempts to fix #19

### DIFF
--- a/src/Network/Wait.hs
+++ b/src/Network/Wait.hs
@@ -4,6 +4,8 @@
 -------------------------------------------------------------------------------
 
 {-# OPTIONS_GHC -Wno-unused-imports #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 
@@ -32,15 +34,38 @@ module Network.Wait (
 
 -------------------------------------------------------------------------------
 
+import Control.Exception (throwIO)
 import Control.Monad.Catch
 import Control.Monad.IO.Class
 import Control.Retry
 -- Only needed for base < 4.11, redundant otherwise
 import Data.Semigroup
+import System.IO.Error
+import System.Timeout
 
 import Network.Socket
 
 -------------------------------------------------------------------------------
+
+-- | Each individual connect attempt needs a timeout to prevent it from hanging
+-- indefinitely. This policy allows us to make that timeout length adaptive,
+-- based on the 'RetryStatus' of the outer retry policy.
+--
+-- Thus, the first attempt to connect will have a short timeout (currently 100ms),
+-- and then successive attempts will get longer timeouts via "FullJitter" backoff.
+-- The goals of this are twofold:
+--
+-- 1) If a connect call hangs during the first few attempts, it is timed out quickly
+-- and re-attempted, so on a healthy network you aren't penalized too much by the hang.
+-- The outer retry policy can control the time between attempts, so the user can set
+-- it high enough to make this be the case.
+--
+-- 2) If the network is slow, we will eventually reach the maximum timeout of 3 seconds,
+-- which should be long enough. Note that the popular wait-for script uses 1 second
+-- timeouts, so this is extra conservative:
+-- https://github.com/eficode/wait-for/blob/7586b3622f010808bb2027c19aaf367221b4ad54/wait-for#L72
+connectRetryPolicy :: MonadIO m => RetryPolicyM m
+connectRetryPolicy = capDelay (3_000_000) (fullJitterBackoff 100_000)
 
 -- | `waitTcp` @retryPolicy hostName serviceName@ is a variant of `waitTcpWith`
 -- which does not install any additional handlers.
@@ -141,13 +166,19 @@ waitSocketWith
     => [RetryStatus -> Handler m Bool] -> RetryPolicyM m -> AddrInfo
     -> m Socket
 waitSocketWith hs policy addr =
-    recoveringWith hs policy $
+    recoveringWith hs policy $ \retryStatus ->
     -- all of the networking code runs in IO
     liftIO $
     -- we want to make sure that we close the socket after every attempt;
     -- `bracket` will re-throw any error afterwards
-    bracket initSocket close $
-        \sock -> connect sock (addrAddress addr) >> pure sock
+    bracket initSocket close $ \sock -> do
+        connectTimeoutUs <- (getRetryPolicyM connectRetryPolicy) retryStatus >>= \case
+            Nothing -> throwIO $ userError "Timeout in connect attempt"
+            Just us -> pure us
+
+        timeout connectTimeoutUs (connect sock (addrAddress addr)) >>= \case
+            Nothing -> throwIO $ userError "Timeout in connect attempt"
+            Just () -> pure sock
     where
         initSocket =
             socket (addrFamily addr) (addrSocketType addr) (addrProtocol addr)
@@ -163,15 +194,13 @@ waitSocketWith hs policy addr =
 -- the standard output or a logger.
 recoveringWith
     :: (MonadIO m, MonadMask m)
-    => [RetryStatus -> Handler m Bool] -> RetryPolicyM m -> m a -> m a
+    => [RetryStatus -> Handler m Bool] -> RetryPolicyM m -> (RetryStatus -> m a) -> m a
 recoveringWith hs policy action =
     -- apply the retry policy to the following code, with the combinations of
     -- the `skipAsyncExceptions`, given, and default handlers. The order of
     -- the handlers matters as they are checked in order.
     recovering policy (skipAsyncExceptions <> hs <> [defHandler]) $
-    -- we want to make sure that we close the socket after every attempt;
-    -- `bracket` will re-throw any error afterwards
-        const action
+        action
     where
         -- our default handler, which works with any exception derived from
         -- `SomeException`, and signals that we should retry if allowed by


### PR DESCRIPTION
Without connect timeouts, I get intermittent hangs on some tests I run. With this change, I ran a whole bunch of repeats and got no failures.

I don't have an exact reproducer for causing the connect call to hang. In my case, it happens when a Kubernetes Service is in the process of starting. According to some googling, hangs can happen for a variety of reasons, such as if the network simply drops packets for a destination that doesn't exist yet.