### PR TITLE
Add `recoveringWithStatus`

### DIFF
--- a/src/Network/Wait/PostgreSQL.hs
+++ b/src/Network/Wait/PostgreSQL.hs
@@ -93,7 +93,7 @@ waitPostgreSqlWith
     => [RetryStatus -> Handler m Bool] -> RetryPolicyM m -> info
     -> m Connection
 waitPostgreSqlWith hs policy info =
-    recoveringWith hs policy $ \_ ->
+    recoveringWith hs policy $
     liftIO $
     bracket (connectDb info) close $ \con -> do
         rs <- query_ @[Int] con "SELECT 1;"

--- a/src/Network/Wait/Redis.hs
+++ b/src/Network/Wait/Redis.hs
@@ -79,6 +79,6 @@ waitRedisWith
     :: (MonadIO m, MonadMask m)
     => [RetryStatus -> Handler m Bool] -> RetryPolicyM m -> ConnectInfo
     -> m Connection
-waitRedisWith hs policy = recoveringWith hs policy . const . liftIO . checkedConnect
+waitRedisWith hs policy = recoveringWith hs policy . liftIO . checkedConnect
 
 -------------------------------------------------------------------------------


### PR DESCRIPTION
This is a small follow-up from #20 which reverts `recoveringWith` to its previous signature and instead adds `recoveringWithStatus` that has the new signature where the `RetryStatus` is given to the `action`. The `recoveringWith` function is now defined in terms of `recoveringWithStatus` to avoid duplication.